### PR TITLE
19 doc add GitHub app setup page

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ To get started with CloudCode, follow these steps:
 CloudCode utilizes a GitHub app to perform actions like PR review and description updates. Here is a quick link to set up your own GitHub App: [docs/pages/github_app.md](docs/pages/github_app.md)
 
 Deploy the API using Docker Compose:
-
 ```
 docker-compose up
 ```
+
+You can also configure features by tweaking the config.json file.
 
 **NOTE:** You need to create a `.env` file by copying `.env.example` and also store the PEM file for the GitHub app as `GITHUB_APP_KEY.pem`.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
-<p align="left">
-  <a href="https://github.com/Cloud-Code-AI/"><img src="https://img.shields.io/github/stars/Cloud-Code-AI/cloudcode" alt="Github Stars"></a>
-  <a href="https://github.com/Cloud-Code-AI/cloudcode/pulse"><img src="https://img.shields.io/github/commit-activity/w/Cloud-Code-AI/cloudcode" alt="Commits-per-week"></a>
-  <a href="https://opensource.org/license/agpl-v3"><img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License: AGPL-3.0"></a>
+<p align="center">
+  <a href="https://github.com/Cloud-Code-AI/">
+    <img src="https://img.shields.io/github/stars/Cloud-Code-AI/cloudcode" alt="Github Stars">
+  </a>
+  <a href="https://github.com/Cloud-Code-AI/cloudcode/pulse">
+    <img src="https://img.shields.io/github/commit-activity/w/Cloud-Code-AI/cloudcode" alt="Commits-per-week">
+  </a>
+  <a href="https://opensource.org/license/agpl-v3">
+    <img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License: AGPL-3.0">
+  </a>
 </p>
 
 # CloudCode
@@ -22,28 +28,42 @@ CloudCode generates comprehensive end-to-end tests based on your application's c
 
 CloudCode RAGifies your code repositories, generating relevant context and allowing you to integrate your own Large Language Models (LLMs) or use pre-trained models. This feature enables you to leverage the power of LLMs for various tasks, such as code generation, documentation, and more.
 
+## File Structure
+
+- `api`: Contains the API server used by the GitHub app to process incoming requests and respond.
+- `cloudcode`: Contains the main logic for interaction with LLMs and data processing.
+  - `actions`: Contains classes used to process various different actions like Code Review.
+  - `llms`: Contains LLM integrations.
+- `docs`: Contains Nextra-powered documentation for the project.
+
 ## Getting Started
 
 To get started with CloudCode, follow these steps:
 
 1. Clone the repository:
 
-```bash
-git clone https://github.com/cloudcode/cloudcode.git
-```
+   ```bash
+   git clone https://github.com/cloudcode/cloudcode.git
+   ```
 
 2. Install dependencies:
 
-```bash
-cd cloudcode
-poetry install
+   ```bash
+   cd cloudcode
+   poetry install
+   ```
+
+### Running API Server for GitHub App
+
+CloudCode utilizes a GitHub app to perform actions like PR review and description updates. Here is a quick link to set up your own GitHub App: [docs/pages/github_app.md](docs/pages/github_app.md)
+
+Deploy the API using Docker Compose:
+
+```
+docker-compose up
 ```
 
-3. Configure your code repository and CI/CD pipeline to integrate with CloudCode.
-
-4. Customize CloudCode's settings and configurations to suit your project's needs.
-
-5. Run CloudCode and enjoy the benefits of automated code review, test generation, and end-to-end testing.
+**NOTE:** You need to create a `.env` file by copying `.env.example` and also store the PEM file for the GitHub app as `GITHUB_APP_KEY.pem`.
 
 ## Contributing
 

--- a/docs/pages/github_app.md
+++ b/docs/pages/github_app.md
@@ -1,0 +1,25 @@
+## Github App Setup
+
+This is a short guide to how to setup your github app:
+
+#### Step 1: Registering Your GitHub App
+- Go to GitHub and click on your profile photo in the upper-right corner of any page.
+- Navigate to your account settings.
+- Click on "Developer settings" in the left sidebar.
+- Select "GitHub Apps" and then click "New GitHub App".
+- Fill in the necessary details for your app:
+  - "GitHub App name": Enter a name for your app.
+  - "Homepage URL": Enter a URL for your app, such as the repository URL where your app's code will be stored.
+  - Under "Webhook", make sure "Active" is selected.
+  - Enter your "Webhook URL", which is the server URL where the webhook requests will be sent.
+  - Optionally, enter a "Webhook secret", a random string that will be used to validate that incoming requests are from GitHub
+
+#### Step 2: Setting Permissions and Events
+- In the sidebar, click "Permissions & events".
+- Under "Repository permissions", "Organization permissions", and "Account permissions", select the permissions your app will need.
+    - Repository Content
+    - Pull Request
+    - Metadata
+    - Check Runs
+- Under "Subscribe to Events", select the webhook events you want your GitHub App to receive, such as "Pull request" if you want to respond to pull request events
+


### PR DESCRIPTION
## Autogenerated PR Description 

## Pull Request Description
This pull request aims to enhance the documentation by adding detailed information about setting up the GitHub app for the CloudCode repository.

### Changes Made
- Added a new file `github_app.md` under the `docs/pages` directory, providing a comprehensive guide on setting up the GitHub app.
- Updated the `README.md` to include a new section 'Running API Server for GitHub App' with instructions on deploying the API using Docker Compose and configuring features.

### Motivation
The motivation behind these changes is to improve the onboarding experience for new users and contributors by providing clear and detailed instructions on setting up the GitHub app for the CloudCode repository. Additionally, the update to the `README.md` aims to streamline the process of running the API server for the GitHub app.


 -- Generated with love by Cloud Code AI


<details>
<summary>Original Description</summary>
Added more info about how this repo works
</details>
